### PR TITLE
feat: Add SecureTextField component and update TextField

### DIFF
--- a/fluent/src/commonMain/kotlin/io/github/composefluent/component/TextField.kt
+++ b/fluent/src/commonMain/kotlin/io/github/composefluent/component/TextField.kt
@@ -1,6 +1,7 @@
 package io.github.composefluent.component
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
@@ -13,9 +14,19 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicSecureTextField
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.KeyboardActionHandler
+import androidx.compose.foundation.text.input.OutputTransformation
+import androidx.compose.foundation.text.input.TextFieldBuffer
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.TextObfuscationMode
+import androidx.compose.foundation.text.input.clearText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
@@ -34,8 +45,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import io.github.composefluent.FluentTheme
 import io.github.composefluent.LocalContentAlpha
@@ -165,6 +179,118 @@ fun TextField(
     }
 }
 
+@Composable
+fun TextField(
+    state: TextFieldState,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    onKeyboardAction: KeyboardActionHandler? = null,
+    inputTransformation: InputTransformation? = null,
+    outputTransformation: OutputTransformation? = null,
+    lineLimits: TextFieldLineLimits = TextFieldLineLimits.Default,
+    header: (@Composable () -> Unit)? = null,
+    leadingIcon: (@Composable () -> Unit)? = null,
+    trailing: (@Composable RowScope.() -> Unit)? = null,
+    placeholder: (@Composable () -> Unit)? = null,
+    isClearable: Boolean = true,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    colors: TextFieldColorScheme = TextFieldDefaults.defaultTextFieldColors(),
+    onTextLayout: (Density.(getResult: () -> TextLayoutResult?) -> Unit)? = null,
+    scrollState: ScrollState = rememberScrollState(),
+    shape: Shape = FluentTheme.shapes.control
+) {
+    val color = colors.schemeFor(interactionSource.collectVisualState(!enabled, focusFirst = true))
+    HeaderContainer(header = header, modifier = modifier) {
+        BasicTextField(
+            modifier = modifier.textFieldModifier(shape),
+            state = state,
+            textStyle = LocalTextStyle.current.copy(color = color.contentColor),
+            enabled = enabled,
+            readOnly = readOnly,
+            onTextLayout = onTextLayout,
+            lineLimits = lineLimits,
+            onKeyboardAction = onKeyboardAction,
+            inputTransformation = inputTransformation,
+            outputTransformation = outputTransformation,
+            scrollState = scrollState,
+            cursorBrush = color.cursorBrush,
+            keyboardOptions = keyboardOptions,
+            interactionSource = interactionSource,
+            decorator = { innerTextField ->
+                TextFieldDefaults.DecorationBox(
+                    state = state,
+                    color = color,
+                    interactionSource = interactionSource,
+                    innerTextField = innerTextField,
+                    enabled = enabled,
+                    placeholder = placeholder,
+                    leadingIcon = leadingIcon,
+                    isClearable = isClearable,
+                    outputTransformation = outputTransformation,
+                    trailing = trailing,
+                    shape = shape
+                )
+            }
+        )
+    }
+}
+
+@Composable
+fun SecureTextField(
+    state: TextFieldState,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    keyboardOptions: KeyboardOptions = SecureTextFieldKeyboardOptions,
+    onKeyboardAction: KeyboardActionHandler? = null,
+    inputTransformation: InputTransformation? = null,
+    textObfuscationMode: TextObfuscationMode = TextObfuscationMode.RevealLastTyped,
+    textObfuscationCharacter: Char = DefaultObfuscationCharacter,
+    header: (@Composable () -> Unit)? = null,
+    leadingIcon: (@Composable () -> Unit)? = null,
+    trailing: (@Composable RowScope.() -> Unit)? = null,
+    placeholder: (@Composable () -> Unit)? = null,
+    isClearable: Boolean = true,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    colors: TextFieldColorScheme = TextFieldDefaults.defaultTextFieldColors(),
+    onTextLayout: (Density.(getResult: () -> TextLayoutResult?) -> Unit)? = null,
+    shape: Shape = FluentTheme.shapes.control
+) {
+    val color = colors.schemeFor(interactionSource.collectVisualState(!enabled, focusFirst = true))
+    HeaderContainer(header = header, modifier = modifier) {
+        BasicSecureTextField(
+            modifier = modifier.textFieldModifier(shape),
+            state = state,
+            textStyle = LocalTextStyle.current.copy(color = color.contentColor),
+            enabled = enabled,
+            onTextLayout = onTextLayout,
+            onKeyboardAction = onKeyboardAction,
+            inputTransformation = inputTransformation,
+            textObfuscationMode = textObfuscationMode,
+            textObfuscationCharacter = textObfuscationCharacter,
+            cursorBrush = color.cursorBrush,
+            keyboardOptions = keyboardOptions,
+            interactionSource = interactionSource,
+            decorator = { innerTextField ->
+                TextFieldDefaults.DecorationBox(
+                    state = state,
+                    color = color,
+                    interactionSource = interactionSource,
+                    innerTextField = innerTextField,
+                    enabled = enabled,
+                    placeholder = placeholder,
+                    leadingIcon = leadingIcon,
+                    isClearable = isClearable,
+                    outputTransformation = null,
+                    trailing = trailing,
+                    shape = shape
+                )
+            }
+        )
+    }
+}
+
 object TextFieldDefaults {
 
     @Stable
@@ -242,7 +368,48 @@ object TextFieldDefaults {
 
     @Composable
     fun DecorationBox(
-        value: String,
+        state: TextFieldState,
+        isClearable: Boolean,
+        outputTransformation: OutputTransformation?,
+        interactionSource: MutableInteractionSource,
+        enabled: Boolean,
+        color: TextFieldColor,
+        modifier: Modifier = Modifier.drawBottomLine(enabled, color, interactionSource),
+        shape: Shape,
+        placeholder: (@Composable () -> Unit)?,
+        leadingIcon: (@Composable () -> Unit)?,
+        trailing: (@Composable RowScope.() -> Unit)?,
+        innerTextField: @Composable () -> Unit,
+    ) {
+        val visualText = if (outputTransformation == null) state.text
+        else {
+            lateinit var buffer: TextFieldBuffer
+            state.edit { buffer = this }
+            with(outputTransformation) { buffer.transformOutput() }
+            buffer.asCharSequence()
+        }
+        DecorationBox(
+            color = color,
+            interactionSource = interactionSource,
+            innerTextField = innerTextField,
+            value = visualText,
+            enabled = enabled,
+            placeholder = placeholder,
+            leadingIcon = leadingIcon,
+            onClearClick = if (isClearable) {
+                { state.clearText() }
+            } else {
+                null
+            },
+            trailing = trailing,
+            shape = shape,
+            modifier = modifier
+        )
+    }
+
+    @Composable
+    fun DecorationBox(
+        value: CharSequence,
         interactionSource: MutableInteractionSource,
         enabled: Boolean,
         color: TextFieldColor,
@@ -368,3 +535,8 @@ internal fun Modifier.textFieldModifier(shape: Shape) =
     defaultMinSize(64.dp, 32.dp).clip(shape)
 
 private val TextFieldContentArrangement = Arrangement.alignLast(Arrangement.Start, Alignment.End)
+
+private val SecureTextFieldKeyboardOptions =
+    KeyboardOptions(autoCorrectEnabled = false, keyboardType = KeyboardType.Password)
+
+private const val DefaultObfuscationCharacter: Char = '\u2022'

--- a/gallery/src/commonMain/kotlin/io/github/composefluent/gallery/screen/text/TextBoxScreen.kt
+++ b/gallery/src/commonMain/kotlin/io/github/composefluent/gallery/screen/text/TextBoxScreen.kt
@@ -1,11 +1,16 @@
 package io.github.composefluent.gallery.screen.text
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import io.github.composefluent.component.SecureTextField
 import io.github.composefluent.component.Text
 import io.github.composefluent.component.TextField
 import io.github.composefluent.gallery.annotation.Component
@@ -36,6 +41,12 @@ fun TextBoxScreen() {
             sourceCode = sourceCodeOfTextBoxHeaderSample,
             content = { TextBoxHeaderSample() }
         )
+
+        Section(
+            title = "A SecureTextBox.",
+            sourceCode = sourceCodeOfSecureTextBoxSample,
+            content = { SecureTextBoxSample() }
+        )
     }
 }
 
@@ -57,4 +68,22 @@ private fun TextBoxHeaderSample() {
         // placeholder = { Text("Name") },
     )
     // TODO: Support placeholder
+}
+
+@Sample
+@Composable
+private fun SecureTextBoxSample() {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        TextField(
+            state = rememberTextFieldState(),
+            header = { Text("Username") }
+        )
+        SecureTextField(
+            state = rememberTextFieldState(),
+            header = { Text("Password") }
+        )
+    }
+
 }


### PR DESCRIPTION
This commit introduces the `SecureTextField` component, which is a text input field designed for securely entering private text like passwords. It also updates the `TextField` component with enhanced functionality.

close #103 
Key changes:

-   **SecureTextField**:
    -   Adds a new `SecureTextField` component that obscures the entered text.
    -   Provides options to customize text obfuscation using `textObfuscationMode` and `textObfuscationCharacter`.
    -   Includes `BasicSecureTextField` for the core text field functionality.
    -   Uses `KeyboardType.Password` by default.
-   **TextField**:
+   **TextField Update**:
     -   Update the `TextField` component and add support `TextFieldState`, `header`, `placeholder`, `trailing`, `leadingIcon`, `clear`.
     -   Refactor `TextField` use new `TextFieldState`.
-   **Sample**:
+   **Gallery Sample**:
     -   Adds a new sample screen that include `SecureTextField` and `TextField` in the Gallery app.
-   Add Password guide in the README.md.