### PR TITLE
[gallery] Update windows title bar

### DIFF
--- a/gallery/proguard-rules.desktop.pro
+++ b/gallery/proguard-rules.desktop.pro
@@ -1,3 +1,26 @@
 -dontwarn com.sun.jna.internal.Cleaner
 -keep class com.sun.jna.** { *; }
 -keep class * implements com.sun.jna.** { *; }
+
+# LayoutHitTestOwner ProGuard rules
+-keep class androidx.compose.foundation.HoverableNode { *; }
+-keep class androidx.compose.foundation.gestures.ScrollableNode { *; }
+
+-keep class androidx.compose.ui.scene.PlatformLayersComposeSceneImpl { *; }
+-keep class androidx.compose.ui.scene.CanvasLayersComposeSceneImpl { *; }
+-keep class androidx.compose.ui.scene.CanvasLayersComposeSceneImpl$AttachedComposeSceneLayer { *; }
+
+-keepclassmembers class androidx.compose.ui.scene.PlatformLayersComposeSceneImpl {
+    private *** getMainOwner();
+}
+
+-keepclassmembers class androidx.compose.ui.scene.CanvasLayersComposeSceneImpl {
+    private *** mainOwner;
+    private *** _layersCopyCache;
+    private *** focusedLayer;
+}
+
+-keepclassmembers class androidx.compose.ui.scene.CanvasLayersComposeSceneImpl$AttachedComposeSceneLayer {
+    private *** owner;
+    private *** isInBounds(...);
+}


### PR DESCRIPTION
1. Rmoved the reflect of LayoutNode .
2. Update Hit Test behavior that addresses an issue where hit test results could be incorrect after moving the window to a different monitor. 