### PR TITLE
Add `focusable` parameter to `Flyout` and defaults to `true`

### DIFF
--- a/fluent/src/commonMain/kotlin/io/github/composefluent/component/AutoSuggestBox.kt
+++ b/fluent/src/commonMain/kotlin/io/github/composefluent/component/AutoSuggestBox.kt
@@ -167,6 +167,7 @@ object AutoSuggestBoxDefaults {
                 paddingToAnchor = PaddingValues()
             ),
             contentPadding = PaddingValues(),
+            focusable = false,
             content = {
                 CompactMode(enabled = compactMode) {
                     val adapter = rememberScrollbarAdapter(state)

--- a/fluent/src/commonMain/kotlin/io/github/composefluent/component/Dialog.kt
+++ b/fluent/src/commonMain/kotlin/io/github/composefluent/component/Dialog.kt
@@ -85,14 +85,14 @@ class DialogSize(
  *
  * @param visible Controls the visibility of the dialog. When `true`, the dialog is shown; otherwise, it's hidden.
  * @param size The size of the dialog, defining its minimum and maximum width. Defaults to [DialogSize.Standard].
- * @param properties Additional properties for the dialog's popup, such as focusability. Defaults to non-focusable.
+ * @param properties Additional properties for the dialog's popup, such as focusability.
  * @param content The composable content to display within the dialog.
  */
 @Composable
 fun FluentDialog(
     visible: Boolean,
     size: DialogSize = DialogSize.Standard,
-    properties: PopupProperties = PopupProperties(focusable = false),
+    properties: PopupProperties = PopupProperties(focusable = true),
     content: @Composable () -> Unit
 ) {
     val visibleState = remember { MutableTransitionState(false) }

--- a/fluent/src/commonMain/kotlin/io/github/composefluent/component/Dropdown.kt
+++ b/fluent/src/commonMain/kotlin/io/github/composefluent/component/Dropdown.kt
@@ -55,8 +55,6 @@ import io.github.composefluent.background.Layer
  * @param onDismissRequest Called when the user requests to dismiss the menu, such as by clicking
  * outside the menu's bounds.
  * @param modifier The modifier to be applied to the menu.
- * @param focusable Whether the menu should be focusable. This affects whether the menu can be
- * navigated using the keyboard.
  * @param onPreviewKeyEvent Called when a key event is received by the menu, before it is dispatched
  * to the focusable content. Return true to consume the event.
  * @param onKeyEvent Called when a key event is received by the menu, after it is dispatched to
@@ -69,7 +67,6 @@ fun DropdownMenu(
     expanded: Boolean,
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
-    focusable: Boolean = false,
     onPreviewKeyEvent: ((KeyEvent) -> Boolean) = { false },
     onKeyEvent: ((KeyEvent) -> Boolean) = { false },
     offset: DpOffset = DpOffset(0.dp, 0.dp), // TODO: Offset
@@ -84,7 +81,7 @@ fun DropdownMenu(
         val popupPositionProvider = DropdownMenuPositionProvider(density, offset)
 
         Popup(
-            properties = PopupProperties(focusable = focusable),
+            properties = PopupProperties(focusable = true),
             onDismissRequest = onDismissRequest,
             onKeyEvent = onKeyEvent,
             onPreviewKeyEvent = onPreviewKeyEvent,

--- a/fluent/src/commonMain/kotlin/io/github/composefluent/component/Flyout.kt
+++ b/fluent/src/commonMain/kotlin/io/github/composefluent/component/Flyout.kt
@@ -71,6 +71,8 @@ import io.github.composefluent.background.calculateBorderPadding
  * @param onPreviewKeyEvent An optional callback invoked when a key event is dispatched to the flyout
  *                          before it is dispatched to any focused view. If not null, it will be
  *                          focusable.
+ * @param focusable Determines whether the flyout is focusable. Setting to false allows user to interact
+ * with the outside area of the flyout. Defaults to `true`.
  * @param content A composable lambda representing the main content within the container.
  *                It also has access to the [FlyoutContainerScope].
  */
@@ -83,6 +85,7 @@ fun FlyoutContainer(
     adaptivePlacement: Boolean = false,
     onKeyEvent: ((keyEvent: KeyEvent) -> Boolean)? = null,
     onPreviewKeyEvent: ((keyEvent: KeyEvent) -> Boolean)? = null,
+    focusable: Boolean = true,
     content: @Composable FlyoutContainerScope.() -> Unit
 ) {
     BasicFlyoutContainer(
@@ -94,6 +97,7 @@ fun FlyoutContainer(
                 adaptivePlacement = adaptivePlacement,
                 onKeyEvent = onKeyEvent,
                 onPreviewKeyEvent = onPreviewKeyEvent,
+                focusable = focusable,
                 content = { flyout() }
             )
         },
@@ -181,6 +185,8 @@ enum class FlyoutPlacement {
  * @param onPreviewKeyEvent Optional callback to preview key events before they are dispatched to
  * the flyout's content. Return `true` to consume the event, `false` to allow it to propagate.
  * Defaults to `null`.
+ * @param focusable Determines whether the flyout is focusable. Setting to false allows user to interact
+ * with the outside area of the flyout. Defaults to `true`.
  * @param content The content to be displayed within the flyout.
  */
 @Composable
@@ -193,6 +199,7 @@ fun Flyout(
     shape: Shape = FluentTheme.shapes.overlay,
     onKeyEvent: ((keyEvent: KeyEvent) -> Boolean)? = null,
     onPreviewKeyEvent: ((keyEvent: KeyEvent) -> Boolean)? = null,
+    focusable: Boolean = true,
     content: @Composable () -> Unit
 ) {
     BasicFlyout(
@@ -206,6 +213,7 @@ fun Flyout(
         shape = shape,
         onKeyEvent = onKeyEvent,
         onPreviewKeyEvent = onPreviewKeyEvent,
+        focusable = focusable,
         content = content
     )
 }
@@ -221,6 +229,7 @@ internal fun BasicFlyout(
     positionProvider: FlyoutPositionProvider = rememberFlyoutPositionProvider(),
     onKeyEvent: ((keyEvent: KeyEvent) -> Boolean)? = null,
     onPreviewKeyEvent: ((keyEvent: KeyEvent) -> Boolean)? = null,
+    focusable: Boolean = true,
     content: @Composable () -> Unit
 ) {
     val visibleState = remember {
@@ -232,7 +241,7 @@ internal fun BasicFlyout(
             onDismissRequest = onDismissRequest,
             properties = PopupProperties(
                 clippingEnabled = false,
-                focusable = onKeyEvent != null || onPreviewKeyEvent != null
+                focusable = focusable
             ),
             popupPositionProvider = positionProvider,
             onKeyEvent = onKeyEvent,
@@ -428,7 +437,7 @@ private class FlyoutContainerScopeImpl(
  * Clicking outside of the flyout will set `isFlyoutVisible` to false, hiding the flyout.
  */
 @OptIn(ExperimentalFluentApi::class)
-interface FlyoutContainerScope: FlyoutAnchorScope {
+interface FlyoutContainerScope : FlyoutAnchorScope {
 
     var isFlyoutVisible: Boolean
 

--- a/fluent/src/commonMain/kotlin/io/github/composefluent/component/MenuFlyout.kt
+++ b/fluent/src/commonMain/kotlin/io/github/composefluent/component/MenuFlyout.kt
@@ -161,7 +161,8 @@ internal fun MenuFlyout(
         positionProvider = positionProvider,
         contentPadding = PaddingValues(vertical = 3.dp),
         onKeyEvent = onKeyEvent,
-        onPreviewKeyEvent = onPreviewKeyEvent
+        onPreviewKeyEvent = onPreviewKeyEvent,
+        focusable = false
     ) {
         val state = rememberScrollState()
         ScrollbarContainer(


### PR DESCRIPTION
The `focusable` parameter in PopupProperties controls certain interaction behaviors, particularly for components like Dialog, Flyout, and Dropdown. Previously, setting it to `false` allowed users to click the DropdownButton multiple times, which causes animation problems.

However, some components do require this behavior. For example, a `MenuBar` needs to be able to display a new menu immediately when the user hovers over another menu button.

So, I exposed this parameter, allows components to choose the expected behavior.

Meanwhile, adjusted the `focusable` setting for Dialog specifically, as Dialog components also need to handle keyboard interactions from users.